### PR TITLE
Remove some innocent warnings

### DIFF
--- a/src/ntb-daemon.c
+++ b/src/ntb-daemon.c
@@ -285,9 +285,9 @@ daemonize(void)
         }
 
         /* Redirect standard files to /dev/null */
-        freopen("/dev/null", "r", stdin);
-        freopen("/dev/null", "w", stdout);
-        freopen("/dev/null", "w", stderr);
+        stdin = freopen("/dev/null", "r", stdin);
+        stdout = freopen("/dev/null", "w", stdout);
+        stderr = freopen("/dev/null", "w", stderr);
 }
 
 static void

--- a/src/ntb-mail-parser.c
+++ b/src/ntb-mail-parser.c
@@ -779,7 +779,7 @@ ntb_mail_parser_parse(struct ntb_mail_parser *parser,
                       size_t length,
                       struct ntb_error **error)
 {
-        ssize_t processed;
+        ssize_t processed = -1;
 
         while (length > 0) {
                 switch (parser->state) {

--- a/src/ntb-quoted-printable.c
+++ b/src/ntb-quoted-printable.c
@@ -209,7 +209,7 @@ ntb_quoted_printable_decode(struct ntb_quoted_printable_data *data,
                             uint8_t *out_buffer,
                             struct ntb_error **error)
 {
-        ssize_t processed;
+        ssize_t processed = -1;
 
         data->out = out_buffer;
 


### PR DESCRIPTION
Remove the following warnings. They pop out when building with gcc 4.6.3 in x64, but don't cause any real problem.

```
ntb-daemon.c: In function ‘daemonize’:
ntb-daemon.c:288:16: warning: ignoring return value of ‘freopen’, declared with attribute warn_unused_result [-Wunused-result]
ntb-daemon.c:289:16: warning: ignoring return value of ‘freopen’, declared with attribute warn_unused_result [-Wunused-result]
ntb-daemon.c:290:16: warning: ignoring return value of ‘freopen’, declared with attribute warn_unused_result [-Wunused-result]

ntb-mail-parser.c: In function ‘ntb_mail_parser_parse’:
ntb-mail-parser.c:782:17: warning: ‘processed’ may be used uninitialized in this function [-Wuninitialized]

ntb-quoted-printable.c: In function ‘ntb_quoted_printable_decode’:
ntb-quoted-printable.c:212:17: warning: ‘processed’ may be used uninitialized in this function [-Wuninitialized]
```
