### PR TITLE
Add support for OpenSSL 1.1.x, fix compilation and warnings

### DIFF
--- a/src/ntb-base58.c
+++ b/src/ntb-base58.c
@@ -50,22 +50,22 @@ ntb_base58_encode(const uint8_t *input,
                   size_t length,
                   char *output)
 {
-        BIGNUM val;
+        BIGNUM* val;
         BN_ULONG part;
         char *p = output;
 
-        BN_init(&val);
+        val = BN_new();
 
-        if (BN_bin2bn(input, length, &val) == NULL)
+        if (BN_bin2bn(input, length, val) == NULL)
                 ntb_fatal("A big number operation failed");
 
-        while (!BN_is_zero(&val)) {
-                part = BN_div_word(&val, 58);
+        while (!BN_is_zero(val)) {
+                part = BN_div_word(val, 58);
                 assert(part >= 0 && part < 58);
                 *(p++) = alphabet[part];
         }
 
-        BN_free(&val);
+        BN_free(val);
 
         /* Make it big-endian */
         reverse_bytes(output, p - output);
@@ -102,34 +102,34 @@ ntb_base58_decode(const char *input,
                   uint8_t *output,
                   size_t output_length)
 {
-        BIGNUM val;
+        BIGNUM* val;
         int bn_result;
         int digit_value;
         int n_bytes;
         size_t i;
 
-        BN_init(&val);
+        val = BN_new();
 
         for (i = 0; i < input_length; i++) {
                 digit_value = get_digit_value(input[i]);
                 if (digit_value == -1)
                         return -1;
 
-                bn_result = BN_mul_word(&val, 58);
+                bn_result = BN_mul_word(val, 58);
                 assert(bn_result);
 
-                bn_result = BN_add_word(&val, digit_value);
+                bn_result = BN_add_word(val, digit_value);
                 assert(bn_result);
         }
 
-        n_bytes = BN_num_bytes(&val);
+        n_bytes = BN_num_bytes(val);
 
         if (n_bytes > output_length)
                 return -1;
 
-        BN_bn2bin(&val, output);
+        BN_bn2bin(val, output);
 
-        BN_free(&val);
+        BN_free(val);
 
         return n_bytes;
 }

--- a/src/ntb-key.c
+++ b/src/ntb-key.c
@@ -25,7 +25,7 @@
 
 #include <string.h>
 #include <openssl/obj_mac.h>
-#include <openssl/ecdh.h>
+#include <openssl/ec.h>
 #include <assert.h>
 
 #include "ntb-key.h"
@@ -135,9 +135,6 @@ ntb_key_new(struct ntb_ecc *ecc,
                 key->encryption_key =
                         ntb_ecc_create_key(ecc, private_encryption_key);
         }
-
-        if (private_encryption_key)
-                ECDH_set_method(key->encryption_key, ECDH_OpenSSL());
 
         if ((params->flags & NTB_KEY_PARAM_RIPE)) {
                 memcpy(key->address.ripe,

--- a/src/ntb-mail-parser.c
+++ b/src/ntb-mail-parser.c
@@ -24,6 +24,7 @@
 #include "config.h"
 
 #include <assert.h>
+#include <sys/types.h>
 
 #include "ntb-mail-parser.h"
 #include "ntb-buffer.h"

--- a/src/ntb-network.c
+++ b/src/ntb-network.c
@@ -1575,7 +1575,7 @@ ntb_network_new(bool add_default_nodes)
          * it would probably end up with a repeatable value anyway.
          * This value doesn't need to be cryptographically secure. */
         memset(&nw->nonce, 0, sizeof nw->nonce);
-        RAND_pseudo_bytes((unsigned char *) &nw->nonce, sizeof nw->nonce);
+        RAND_bytes((unsigned char *) &nw->nonce, sizeof nw->nonce);
 
         /* Add a hard-coded list of initial nodes which we can use to
          * discover more */


### PR DESCRIPTION
Since OpenSSL 1.1, some method signatures were removed which results in issues like #14. Now this code is working with OpenSSL 1.1.

Also added a missing include when compiling with `clang` on macOS and removed the deprecated `RAND_pseudo_bytes`.
